### PR TITLE
skip dead characters in move instructions [#89220574]

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -118,9 +118,9 @@ var Game = {
     var result = [];
     for(var i = 0 ; i < orderedKeys.length; i++){
       currentCharacter = this.characters[orderedKeys[i]];
-      //if(!currentCharacter.dead){
+      if(!currentCharacter.dead){
         result.push(Util.moveDescription(currentCharacter));
-      //}
+      }
     }
     this.moveInstructions = result;
     return result;


### PR DESCRIPTION
seem to have just turned this off for some reason while debugging earlier problems. easy fix.
